### PR TITLE
Return a list of products on empty search

### DIFF
--- a/src/main/java/miu/edu/cs425/edeliver/controllers/AdminController.java
+++ b/src/main/java/miu/edu/cs425/edeliver/controllers/AdminController.java
@@ -84,8 +84,8 @@ public class AdminController {
 		Product product=this.productServices.getProductByName(name);
 		if(product==null)
 		{
-			model.addAttribute("message", "SORRY...!  Product Unavailable");
-			model.addAttribute("product", product);
+			List<Product>products=this.productServices.getAllProducts();
+			model.addAttribute("products", products);
 			List<Orders> orders = this.orderServices.getOrdersForUser(user);
 			model.addAttribute("orders", orders);
 			return "BuyProduct";

--- a/src/main/resources/templates/BuyProduct.html
+++ b/src/main/resources/templates/BuyProduct.html
@@ -87,7 +87,7 @@
 
 		<form action="" th:action="@{/product/search}" method="post" class="searchInput">
 			<h1>Product Search :</h1>
-			<input type="text" name="productName" required placeholder="Please enter the Product Name....">
+			<input type="text" name="productName">
 			<button type="submit">SEARCH</button><br />
 			<smal style="color: red;" th:text="${message}"> </smal>
 		</form>
@@ -98,11 +98,39 @@
 				<input type="text" value="" name="oName" th:value="${product.pname}" readonly /><br />
 				Product Price :
 				<input type="text" value="" name="oPrice" th:value="${product.pprice}" readonly /><br />
-				Quqntity :
+				Quantity :
 				<input type="number" placeholder="Minimun: 1KG" min="1" name="oQuantity" /><br />
 
 				<button type="submit">Order_Now</button>
 			</form>
+		</div>
+
+		<div th:if="${products!=null}" class="details">
+			<h2>Products in db :</h2>
+			<table >
+				<tr>
+
+					<th>Product_Name</th>
+					<th>Product_Price</th>
+					<th>Product_Quantity</th>
+					<th>Actions</th>
+				</tr>
+				<tr th:each="product :${products}">
+					<td th:text="${product.pname}"></td>
+					<td th:text="${product.pprice}"></td>
+					<td>
+						<form action="" th:action="@{/product/order}" th:object="${product}" method="post">
+							<input type="hidden" value="" name="oName" th:value="${product.pname}" />
+							<input type="hidden" value="" name="oPrice" th:value="${product.pprice}" />
+							<input type="number" placeholder="Minimun: 1KG" min="1" name="oQuantity" />
+					</td>
+					<td>
+						<button type="submit">Order_Now</button>
+						</form>
+					</td>
+
+				</tr>
+			</table>
 		</div>
 		
 		<div th:if="${orders!=null}" class="details">


### PR DESCRIPTION
Clicking on the "Search" button without filling the text field with value results in a required validation error. However, I believe we need some kind of a list in there to assist the user in making a choice to their orders since they might not might not know what products are available in the store. Therefore, I tuned the search functionality a little bit. 

- Now when you make an empty text search it will provide a products list for the users to select items to order. 